### PR TITLE
change markdown editor to simplemde

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ gem 'fog'
 gem 'carrierwave-aws'
 gem 'figaro'
 gem 'aasm'
-gem 'pagedown-bootstrap-rails'
 gem 'redcarpet'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,8 +263,6 @@ GEM
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
     orm_adapter (0.5.0)
-    pagedown-bootstrap-rails (2.1.3)
-      railties (> 3.1)
     pg (0.18.4)
     pkg-config (1.1.7)
     pry (0.10.4)
@@ -385,7 +383,6 @@ DEPENDENCIES
   jquery-rails
   listen (~> 3.0.5)
   mini_magick
-  pagedown-bootstrap-rails
   pg
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -15,6 +15,4 @@
 //= require bootstrap/alert
 //= require bootstrap/dropdown
 //= require bootstrap-sprockets
-//= require pagedown_bootstrap
-//= require pagedown_init
 //= require_tree .

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,7 +15,6 @@
  *= require_self
  */
 
-@import "pagedown_bootstrap";
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "font-awesome";

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -19,7 +19,8 @@ module ApplicationHelper
       lax_spacing:        true,
       no_intra_emphasis:  true,
       strikethrough:      true,
-      superscript:        true
+      superscript:        true,
+      tables:             true
     }
 
     renderer = Redcarpet::Render::HTML.new(html_render_options)

--- a/app/views/admin/courses/edit.html.erb
+++ b/app/views/admin/courses/edit.html.erb
@@ -1,11 +1,11 @@
-<h1> New Course </h1>
+<h1> Edit Course </h1>
 <%= simple_form_for [:admin, @course] do |f| %>
 <%= f.input :title %>
 <%= f.input :description %>
 <%= f.input :price %>
 <%= f.input :teacher_name %>
 <%= f.input :image %>
-<%= f.submit "Edit Course" %>
+<%= f.submit %>
 <% end %>
 
 

--- a/app/views/admin/courses/edit.html.erb
+++ b/app/views/admin/courses/edit.html.erb
@@ -1,9 +1,15 @@
 <h1> New Course </h1>
 <%= simple_form_for [:admin, @course] do |f| %>
 <%= f.input :title %>
-<%= f.input :description, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+<%= f.input :description %>
 <%= f.input :price %>
 <%= f.input :teacher_name %>
 <%= f.input :image %>
 <%= f.submit "Edit Course" %>
 <% end %>
+
+
+<script>
+var simplemde = new SimpleMDE({ element: document.getElementById("course_description") });
+simplemde.value();
+</script>

--- a/app/views/admin/courses/new.html.erb
+++ b/app/views/admin/courses/new.html.erb
@@ -1,9 +1,14 @@
 <h1> New Course </h1>
 <%= simple_form_for [:admin, @course] do |f| %>
 <%= f.input :title %>
-<%= f.input :description, as: :pagedown, input_html: { preview: true, rows: 10 } %>
+<%= f.input :description %>
 <%= f.input :price %>
 <%= f.input :teacher_name %>
 <%= f.input :image %>
 <%= f.submit "Create Course" %>
 <% end %>
+
+
+<script>
+var simplemde = new SimpleMDE({ element: document.getElementById("course_description") });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,8 @@
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.css">
+    <script src="https://cdn.jsdelivr.net/simplemde/latest/simplemde.min.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
更换了新的 markdown 编辑器，使用如下 javascript 代码调用：


var simplemde = new SimpleMDE({ element: document.getElementById("#id") });
simplemde.value();


解说：
第一行是根据 html 元素的 id 来定位编辑器所在的位置，将代码中的 #id 更换成对应的 id 值即可，示例：

```
<h1> New Course </h1>
<%= simple_form_for [:admin, @course] do |f| %>
<%= f.input :title %>
<%= f.input :description %>
<%= f.input :price %>
<%= f.input :teacher_name %>
<%= f.input :image %>
<%= f.submit "Edit Course" %>
<% end %>


<script>
var simplemde = new SimpleMDE({ element: document.getElementById("course_description") });
simplemde.value();
</script>
```

其中的 course_description 是 `<%= f.input :description %>` 的 id 值，所以该编辑器会在 description 那一栏出现。

`simplemde.value();` 的意思是取值，用于编辑该栏位已有的值，经常用于类似 `edit.html.erb` 这样的页面（因为 `new.html.erb` 的页面里，所有栏位都没有值，等待新建，所以不需要这句代码）。

