### PR TITLE
fix a path typo in orders_controller.rb

### DIFF
--- a/app/controllers/account/orders_controller.rb
+++ b/app/controllers/account/orders_controller.rb
@@ -70,6 +70,6 @@ class Account::OrdersController < ApplicationController
 
     end
 
-    redirect_to account_orders_pat
+    redirect_to account_orders_path
   end
 end


### PR DESCRIPTION
修复了一个 orders controller 里路径的拼写错误
