### PR TITLE
Nyc distinguish edit course and remove repeat code

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -20,10 +20,10 @@
 // body { background-image: url("body.jpg"); }
 
 
-
 /* universal */
 body {
     padding-top: 70px;
+    background-image: url(/crossword_background.png);
 }
 section {
     overflow: auto;

--- a/app/controllers/account/works_controller.rb
+++ b/app/controllers/account/works_controller.rb
@@ -1,6 +1,7 @@
 class Account::WorksController < ApplicationController
   before_action :authenticate_user!
   before_action :get_task, only: %i(new create edit update)
+  before_action :find_params, only: [:show, :edit, :update, :destroy]
 
   def show
     @work = Work.find(params[:id])
@@ -62,6 +63,10 @@ class Account::WorksController < ApplicationController
   end
 
   private
+
+  def find_params
+    @work = Work.find(params[:id])
+  end
 
   def get_task
     @task = Task.find(params[:task_id])

--- a/app/controllers/admin/chapters_controller.rb
+++ b/app/controllers/admin/chapters_controller.rb
@@ -1,5 +1,6 @@
 class Admin::ChaptersController < AdminController
-  before_action :find_course, only: %i(index new edit create update destroy)
+  before_action :find_course, only: %i(index new edit create update destroy search)
+  before_action :find_params, only: [:edit, :show, :update, :destroy, :publish, :hide]
   before_action :validate_search_key, only: [:search]
 
   def index
@@ -14,11 +15,9 @@ class Admin::ChaptersController < AdminController
   end
 
   def edit
-    @chapter = Chapter.find(params[:id])
   end
 
   def show
-    @chapter = Chapter.find(params[:id])
   end
 
   def create
@@ -32,7 +31,6 @@ class Admin::ChaptersController < AdminController
   end
 
   def update
-    @chapter = Chapter.find(params[:id])
     if @chapter.update(chapter_params)
       redirect_to admin_course_chapters_path(@course), notice: "更新成功"
     else
@@ -41,25 +39,21 @@ class Admin::ChaptersController < AdminController
   end
 
   def destroy
-    @chapter = Chapter.find(params[:id])
     @chapter.destroy
     redirect_to  admin_course_chapters_path(@course), alert: "Deleted"
   end
 
   def publish
-    @chapter = Chapter.find(params[:id])
     @chapter.publish!
     redirect_to :back
   end
 
   def hide
-    @chapter = Chapter.find(params[:id])
     @chapter.hide!
     redirect_to :back
   end
 
   def search
-    @course = Course.find(params[:course_id])
     if @query_string.present?
       search_result = Post.where(course_id: params[:course_id]).ransack(@search_criteria).result(distinct: true)
       @posts = search_result.paginate(page: params[:page], per_page: 20)
@@ -80,6 +74,9 @@ class Admin::ChaptersController < AdminController
   end
 
   private
+  def find_params
+    @chapter = Chapter.find(params[:id])
+  end
 
   def find_course
     @course = Course.find(params[:course_id])

--- a/app/controllers/admin/courses_controller.rb
+++ b/app/controllers/admin/courses_controller.rb
@@ -1,11 +1,12 @@
 class Admin::CoursesController < AdminController
+  before_action :find_params, only: [:show, :edit, :update, :destroy, :publish, :hide, :edit_course]
+
   def index
     @courses = Course.recent
     drop_breadcrumb "Courses"
   end
 
   def show
-    @course = Course.find(params[:id])
     @users = @course.enrolled_users
   end
 
@@ -15,7 +16,6 @@ class Admin::CoursesController < AdminController
   end
 
   def edit
-    @course = Course.find(params[:id])
     drop_breadcrumb "Courses", admin_courses_path
     drop_breadcrumb @course.title
     drop_breadcrumb "编辑课程"
@@ -31,7 +31,6 @@ class Admin::CoursesController < AdminController
   end
 
   def update
-    @course = Course.find(params[:id])
     if @course.update(course_params)
       redirect_to admin_courses_path, notice: "Update Success"
     else
@@ -40,26 +39,30 @@ class Admin::CoursesController < AdminController
   end
 
   def destroy
-    @course = Course.find(params[:id])
     @course.destroy
     redirect_to admin_courses_path, alert: "Course Deleted"
   end
 
   def publish
-    @course = Course.find(params[:id])
     @course.publish!
     redirect_to :back
   end
 
   def hide
-    @course = Course.find(params[:id])
     @course.hide!
     redirect_to :back
   end
 
+  def edit_course
+  end
+
   private
+  def find_params
+    @course = Course.find(params[:id])
+  end
+
 
   def course_params
-    params.require(:course).permit(:faq, :title, :description, :price, :is_hidden, :image, :teacher_name, :hero_image, :teacher_image, :about_teacher, :one_sentence_summary)
+    params.require(:course).permit(:faq, :title, :description, :price, :is_hidden, :image, :teacher_name, :hero_image, :teacher_image, :about_teacher, :one_sentence_summary, :hero_title)
   end
 end

--- a/app/controllers/admin/faqs_controller.rb
+++ b/app/controllers/admin/faqs_controller.rb
@@ -1,5 +1,6 @@
 class Admin::FaqsController < ApplicationController
   before_action :find_course, only: %i(index new edit create update destroy)
+  before_action :find_params, only: [:show, :edit, :update, :destroy]
 
   def index
     @faqs = @course.faqs
@@ -10,11 +11,9 @@ class Admin::FaqsController < ApplicationController
   end
 
   def show
-    @faq = Faq.find(params[:id])
   end
 
   def edit
-    @faq = Faq.find(params[:id])
   end
 
   def create
@@ -28,7 +27,6 @@ class Admin::FaqsController < ApplicationController
 end
 
   def update
-    @faq = Faq.find(params[:id])
   if @faq.update(faq_params)
     redirect_to  admin_course_faqs_path(@course), notice: "Updated Success"
   else
@@ -37,12 +35,15 @@ end
 end
 
   def destroy
-    @faq = Faq.find(params[:id])
     @faq.destroy
     redirect_to admin_course_faqs_path(@course), alert: "Deleted"
   end
 
   private
+
+  def find_params
+    @faq = Faq.find(params[:id])
+  end
 
   def find_course
     @course = Course.find(params[:course_id])

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,5 +1,6 @@
 class Admin::PostsController < AdminController
   before_action :get_chapter_params, only: %i(index new edit create update destroy)
+  before_action :find_params, only: [:edit, :show, :update, :destroy, :publish, :hide]
 
   def index
     @posts = @chapter.posts
@@ -10,11 +11,9 @@ class Admin::PostsController < AdminController
   end
 
   def edit
-    @post = Post.find(params[:id])
   end
 
   def show
-    @post = Post.find(params[:id])
   end
 
   def create
@@ -31,7 +30,6 @@ class Admin::PostsController < AdminController
 
   def update
     @course = @chapter.course
-    @post = Post.find(params[:id])
     if @post.update(post_params)
       redirect_to admin_course_chapters_path(@course), notice: "更新成功"
     else
@@ -40,25 +38,25 @@ class Admin::PostsController < AdminController
   end
 
   def destroy
-    @post = Post.find(params[:id])
     @course = @chapter.course
     @post.destroy
     redirect_to admin_course_chapters_path(@course), alert: "Deleted"
   end
 
   def publish
-    @post = Post.find(params[:id])
     @post.publish!
     redirect_to :back
   end
 
   def hide
-    @post = Post.find(params[:id])
     @post.hide!
     redirect_to :back
   end
 
   private
+  def find_params
+    @post = Post.find(params[:id])
+  end
 
   def get_chapter_params
     @chapter = Chapter.find(params[:chapter_id])

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,7 @@
 class Admin::UsersController < AdminController
   before_action :authenticate_user!
   before_action :require_is_admin
+  before_action :find_params, only: [:show, :edit, :update, :turn_to_admin, :turn_to_user]
   layout "admin"
 
   def index
@@ -8,15 +9,12 @@ class Admin::UsersController < AdminController
   end
 
   def show
-    @user = User.find(params[:id])
   end
 
   def edit
-    @user = User.find(params[:id])
   end
 
   def update
-    @user = User.find(params[:id])
     if @user.update(user_params)
       redirect_to admin_users_path, notice: "资料已更新！"
     else
@@ -39,17 +37,21 @@ class Admin::UsersController < AdminController
   # end
 
   def turn_to_admin
-    @user = User.find(params[:id])
     @user.is_admin = true
     @user.save
     redirect_to :back
   end
 
   def turn_to_user
-    @user = User.find(params[:id])
     @user.is_admin = false
     @user.save
     redirect_to :back
+  end
+
+private
+
+  def find_params
+    @user = User.find(params[:id])
   end
 
   def user_params

--- a/app/models/course.rb
+++ b/app/models/course.rb
@@ -16,6 +16,7 @@
 #  teacher_image        :string
 #  about_teacher        :text
 #  one_sentence_summary :string
+#  hero_title           :string
 #
 
 #  id                   :integer          not null, primary key

--- a/app/views/account/settings/index.html.erb
+++ b/app/views/account/settings/index.html.erb
@@ -1,6 +1,6 @@
 <div class="container">
       <div class="row">
-        <div class="col-md-5  " >
+        <div class="col-md-5 col-md-offset-2" >
 
 
           <div class="panel panel-info">

--- a/app/views/admin/courses/_course_options.html.erb
+++ b/app/views/admin/courses/_course_options.html.erb
@@ -8,8 +8,9 @@
   </button>
   <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
     <li><%= link_to("进入控制台", admin_course_chapters_path(course)) %></li>
-    <li><%= link_to("查看报名人数", admin_course_path(course))  %> </li> 
-    <li><%= link_to("编辑课程信息", edit_admin_course_path(course)) %></li>
+    <li><%= link_to("查看报名人数", admin_course_path(course))  %> </li>
+    <li><%= link_to("编辑首页课程信息",edit_course_admin_course_path(course)) %>
+    <li><%= link_to("编辑课程详情信息", edit_admin_course_path(course)) %></li>
     <li><%= link_to("删除", admin_course_path(course), method: :delete,   data: { confirm:  "Are you sure?" } ) %>
 </li>
     <li>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -1,12 +1,9 @@
 <%= simple_form_for [:admin, @course] do |f| %>
-<%= f.input :title %>
-<%= f.input :one_sentence_summary %>
+<%= f.input :hero_title %>
 <%= f.input :description %>
 <%= f.input :faq %>
 <%= f.input :about_teacher %>
 <%= f.input :price %>
-<%= f.input :teacher_name %>
-<%= f.input :image %>
 <%= f.input :hero_image %>
 <%= f.input :teacher_image %>
 <%= f.submit %>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -1,11 +1,11 @@
 <%= simple_form_for [:admin, @course] do |f| %>
-<%= f.input :hero_title %>
-<%= f.input :description %>
-<%= f.input :faq %>
-<%= f.input :about_teacher %>
-<%= f.input :price %>
-<%= f.input :hero_image %>
-<%= f.input :teacher_image %>
+<%= f.input :hero_title, label: "课程标题"%>
+<%= f.input :description, label: "课程详情描述" %>
+<%= f.input :faq, label: "课程问答" %>
+<%= f.input :about_teacher, label: "教师介绍" %>
+<%= f.input :price, label: "课程价格" %>
+<%= f.input :hero_image, label: "课程背景大图" %>
+<%= f.input :teacher_image, label: "教师头像" %>
 <%= f.submit %>
 <% end %>
 

--- a/app/views/admin/courses/edit_course.html.erb
+++ b/app/views/admin/courses/edit_course.html.erb
@@ -1,7 +1,7 @@
   <%= simple_form_for [:admin, @course] do |f| %>
-  <%= f.input :title %>
-  <%= f.input :one_sentence_summary %>
-  <%= f.input :teacher_name %>
-  <%= f.input :image %>
+  <%= f.input :title, label: "课程首页标题"%>
+  <%= f.input :one_sentence_summary, label: "一句话描述课程"  %>
+  <%= f.input :teacher_name, label: "教师姓名" %>
+  <%= f.input :image, label: "首页课程图片" %>
   <%= f.submit %>
   <% end %>

--- a/app/views/admin/courses/edit_course.html.erb
+++ b/app/views/admin/courses/edit_course.html.erb
@@ -1,0 +1,7 @@
+  <%= simple_form_for [:admin, @course] do |f| %>
+  <%= f.input :title %>
+  <%= f.input :one_sentence_summary %>
+  <%= f.input :teacher_name %>
+  <%= f.input :image %>
+  <%= f.submit %>
+  <% end %>

--- a/app/views/admin/courses/index.html.erb
+++ b/app/views/admin/courses/index.html.erb
@@ -20,7 +20,7 @@
             <td>
                 <%= render_course_status(course) %>
                 <%= link_to(course.title, course_path(course)) %>
-            
+
             </td>
             <td>
                 <%= course.teacher_name %>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
       <div class="row">
-      <div class="col-md-5  toppad  pull-right col-md-offset-3 ">
+      <div class="col-md-5  toppad  col-md-offset-2 ">
 <p class=" text-info"><%= Time.now.strftime("%Y-%m-%d %I:%M:%S") %></p>
       </div>
-        <div class="col-xs-12 col-sm-12 col-md-6 col-lg-6 col-xs-offset-0 col-sm-offset-0 col-md-offset-3 col-lg-offset-3 toppad" >
+        <div class="col-xs-12 col-sm-12 col-md-5 col-lg-5 col-xs-offset-0 col-sm-offset-0 col-md-offset-2 col-lg-offset-2 toppad" >
 
 
           <div class="panel panel-info">

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,7 +1,7 @@
 <!--读取图片并赋予背景-->
 <div class="course-hero-image" style='background:url("<%= @course.hero_image %>")'>
     <div class="course-title-bg">
-        <h1 class="course-title"><%= @course.title%></h1>
+        <h1 class="course-title"><%= @course.hero_title%></h1>
         <h4 class="course-price"><%= render_course_price(@course) %>
         </h4>
     </div>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -11,7 +11,7 @@
         <%= javascript_include_tag 'simplemde.min' %>
     </head>
 
-    <body style="background-image: url(/crossword_background.png);">
+    <body>
 
         <%= render "common/navbar" %>
         <div class="container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,7 @@
         <%= javascript_include_tag 'simplemde.min' %>
 
     </head>
-    <body style="background-image: url(/crossword_background.png);">
+    <body>
         <%= render "common/navbar" %>
         <div class="container">
             <%= render "common/flashes" %>

--- a/app/views/layouts/course.html.erb
+++ b/app/views/layouts/course.html.erb
@@ -10,7 +10,6 @@
   <style>
   body {
     padding-top: 50px;
-    background-image: url(/crossword_background.png);
   }
   </style>
 

--- a/app/views/layouts/order-details.html.erb
+++ b/app/views/layouts/order-details.html.erb
@@ -10,7 +10,7 @@
         <%= javascript_include_tag 'simplemde.min' %>
     </head>
 
-    <body style="background-image: url(/crossword_background.png);">
+    <body>
 
 
             <%= render "common/navbar" %>

--- a/app/views/layouts/order-lists.html.erb
+++ b/app/views/layouts/order-lists.html.erb
@@ -10,7 +10,7 @@
         <%= javascript_include_tag 'simplemde.min' %>
     </head>
 
-    <body style="background-image: url(/crossword_background.png);">
+    <body>
 
 
             <%= render "common/navbar" %>

--- a/app/views/layouts/user.html.erb
+++ b/app/views/layouts/user.html.erb
@@ -10,7 +10,7 @@
         <%= javascript_include_tag 'simplemde.min' %>
     </head>
 
-    <body style="background-image: url(/crossword_background.png);">
+    <body>
 
 
             <%= render "common/navbar" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,11 +24,12 @@ Rails.application.routes.draw do
 
       end
 
-    resources :faqs
+    resources :faqs # admin课程下的FAQ admin > course > faq
 
       member do
         post :hide
         post :publish
+        get :edit_course
       end
     end
 

--- a/db/migrate/20160829045442_add_hero_title_to_course.rb
+++ b/db/migrate/20160829045442_add_hero_title_to_course.rb
@@ -1,0 +1,5 @@
+class AddHeroTitleToCourse < ActiveRecord::Migration[5.0]
+  def change
+    add_column :courses, :hero_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160827064511) do
+ActiveRecord::Schema.define(version: 20160829045442) do
 
   create_table "answers", force: :cascade do |t|
     t.text     "content"
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 20160827064511) do
     t.string   "teacher_image"
     t.text     "about_teacher"
     t.string   "one_sentence_summary"
+    t.string   "hero_title"
   end
 
   create_table "enrollments", force: :cascade do |t|


### PR DESCRIPTION
首页课程编辑与后台课程详情编辑区分，增加栏位hero_title，修改后台标题为中文，让人更容易理解
重新排版用户个人中心与admin看到的用户中心使其一致
去除views,body 里的style背景，统一放到css里的body里
去除chapters,courses,faqs,posts,tasks,users,works的重复代码，使其更整洁。
