### PR TITLE
changed add course to index

### DIFF
--- a/app/views/admin/courses/_course_options.html.erb
+++ b/app/views/admin/courses/_course_options.html.erb
@@ -9,8 +9,8 @@
   </button>
   <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
     <li><%= link_to("查看报名人数", admin_course_path(course))  %> </li>
-    <li><%= link_to("编辑首页课程信息",edit_course_admin_course_path(course)) %>
-    <li><%= link_to("编辑课程详情信息", edit_admin_course_path(course)) %></li>
+    <li><%= link_to("编辑首页课程信息", edit_admin_course_path(course)) %></li>
+    <li><%= link_to("编辑课程详情信息", edit_course_admin_course_path(course)) %></li>
     <li>
       <%= link_to("删除", admin_course_path(course), method: :delete,   data: { confirm:  "Are you sure?" } ) %>
     </li>

--- a/app/views/admin/courses/_form.html.erb
+++ b/app/views/admin/courses/_form.html.erb
@@ -1,20 +1,7 @@
 <%= simple_form_for [:admin, @course] do |f| %>
-<%= f.input :hero_title, label: "课程标题"%>
-<%= f.input :description, label: "课程详情描述" %>
-<%= f.input :faq, label: "课程问答" %>
-<%= f.input :about_teacher, label: "教师介绍" %>
-<%= f.input :price, label: "课程价格" %>
-<%= f.input :hero_image, label: "课程背景大图" %>
-<%= f.input :teacher_image, label: "教师头像" %>
+<%= f.input :title, label: "课程首页标题"%>
+<%= f.input :one_sentence_summary, label: "一句话描述课程"  %>
+<%= f.input :teacher_name, label: "教师姓名" %>
+<%= f.input :image, label: "首页课程图片" %>
 <%= f.submit %>
 <% end %>
-
-
-<script>
-var simplemde_1 = new SimpleMDE({ element: document.getElementById("course_description") });
-var simplemde_2 = new SimpleMDE({ element: document.getElementById("course_faq") });
-var simplemde_3 = new SimpleMDE({ element: document.getElementById("course_about_teacher") });
-simplemde_1.value();
-simplemde_2.value();
-simplemde_3.value();
-</script>

--- a/app/views/admin/courses/edit_course.html.erb
+++ b/app/views/admin/courses/edit_course.html.erb
@@ -1,7 +1,19 @@
-  <%= simple_form_for [:admin, @course] do |f| %>
-  <%= f.input :title, label: "课程首页标题"%>
-  <%= f.input :one_sentence_summary, label: "一句话描述课程"  %>
-  <%= f.input :teacher_name, label: "教师姓名" %>
-  <%= f.input :image, label: "首页课程图片" %>
-  <%= f.submit %>
-  <% end %>
+<%= simple_form_for [:admin, @course] do |f| %>
+<%= f.input :hero_title, label: "课程标题"%>
+<%= f.input :description, label: "课程详情描述" %>
+<%= f.input :faq, label: "课程问答" %>
+<%= f.input :about_teacher, label: "教师介绍" %>
+<%= f.input :price, label: "课程价格" %>
+<%= f.input :hero_image, label: "课程背景大图" %>
+<%= f.input :teacher_image, label: "教师头像" %>
+<%= f.submit %>
+<% end %>
+
+<script>
+var simplemde_1 = new SimpleMDE({ element: document.getElementById("course_description") });
+var simplemde_2 = new SimpleMDE({ element: document.getElementById("course_faq") });
+var simplemde_3 = new SimpleMDE({ element: document.getElementById("course_about_teacher") });
+simplemde_1.value();
+simplemde_2.value();
+simplemde_3.value();
+</script>


### PR DESCRIPTION
修复了新增课程没有值显示目录的bug
现在新增课程是直接新增在课程在index显示的详情，课程里的show详情需要在admin的课程详情选项里进行编辑。
这样做是为了避免了新增课程编辑不同的页面且栏位过多导致的混乱。
